### PR TITLE
Fix #2 on recent versions of bignum

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for OpenTelemetry-SDK
 
 {{$NEXT}}
 
+    * Support recent versions of bignum, which broke
+      OpenTelemetry::SDK::Trace::Sampler::TraceIDRatioBased
+      (https://github.com/jjatria/perl-opentelemetry-sdk/issues/2)
+
 0.016     2023-11-19 11:42:51+00:00 Europe/London
 
     * Do not warn if ending an ended span. This is to support the use

--- a/lib/OpenTelemetry/SDK/Trace/Sampler/TraceIDRatioBased.pm
+++ b/lib/OpenTelemetry/SDK/Trace/Sampler/TraceIDRatioBased.pm
@@ -52,7 +52,9 @@ class OpenTelemetry::SDK::Trace::Sampler::TraceIDRatioBased
         # in the range from 0 (never sample) to 2**64 (always sample)
         $threshold = do {
             use bignum;
-            ( $ratio * 1 << 64 )->bceil;
+            # Since Math::BigFloat 1.999840 onwards, the shift operators are
+            # exclusively integer-based, so we enforce precedent here
+            ( $ratio * ( 1 << 64 ) )->bceil;
         };
     }
 


### PR DESCRIPTION
The failures in `t/OpenTelemetry/SDK/Trace/Sampler/TraceIDRatioBased.t` are caused by a behaviour change in Math::BigInt (which powers `bignum`), this change _should_ fix it in a backward-compatible way.