### PR TITLE
Allow running batch submission in-process

### DIFF
--- a/t/OpenTelemetry/SDK/Trace/Span/Processor/Batch.t
+++ b/t/OpenTelemetry/SDK/Trace/Span/Processor/Batch.t
@@ -195,7 +195,7 @@ tests 'Flush queue' => sub {
 tests 'Ignore calls on shutdown' => sub {
     my $processor = CLASS->new( exporter => my $exporter = Local::Test->new );
 
-    $processor->shutdown;
+    $processor->shutdown->get;
     is $exporter->calls, [ [ 'shutdown' ] ], 'Calling shutdown propagates to exporter';
     $exporter->reset;
 


### PR DESCRIPTION
When debugging, I found it more useful to have the trace submission run in-process.

This implements a config flag to allow that.

This might not be worth merging, but raising as a PR for visibility in case it's useful to others. Separately, I think "submit asynchronously via Net::Async::HTTP or equivalent" could be a useful feature, so that would be another case where the exporter would want to run in-process.