### PR TITLE
IO::Async::Function workers already spawned

### DIFF
--- a/lib/OpenTelemetry/SDK/Trace/Span/Processor/Batch.pm
+++ b/lib/OpenTelemetry/SDK/Trace/Span/Processor/Batch.pm
@@ -88,11 +88,6 @@ class OpenTelemetry::SDK::Trace::Span::Processor::Batch
         );
 
         IO::Async::Loop->new->add($function);
-
-        # TODO: Should this be made configurable? The Ruby SDK
-        # allows users to not start the thread on boot, although
-        # this is not standard
-        $function->start;
     }
 
     method $report_dropped_spans ( $reason, $count ) {


### PR DESCRIPTION
## Background

I fell into this rabbit-hole while instrumenting a Mojolicious application. After switching exporters from 'console' to 'otlp', `morbo` stopped hot-reloading. On code update, morbo would hang until ^c, and then would reload as expected. Issues were also experienced with hypnotoad. When deployed via systemd, a timeout would be reported -- though the application threads would remain and the application was listening to ports and otherwise behaving as expected. The parent thread, when `kill`ed would close all the child threads; but would itself remain until killed a second time.

A minimal working example that exhibits this behavior is provided here: 

```perl
#!/usr/bin/env perl
use Mojolicious::Lite -signatures;

use OpenTelemetry::Exporter::OTLP;
use OpenTelemetry::SDK::Trace::Span::Processor::Batch;

my $exporter = OpenTelemetry::Exporter::OTLP->new;
my $processor = OpenTelemetry::SDK::Trace::Span::Processor::Batch->new(exporter=>$exporter);

get '/' => sub ($c) {
	$c->render(template => 'index',
		processor => $processor,
		exporter => $exporter,
	);
};

app->start;
__DATA__

@@ index.html.ep
% layout 'default';
% title 'Welcome';
<h1>Welcome to the Mojolicious real-time web framework!</h1>
</br><%= ref $processor %>
</br><%= ref $exporter %>

@@ layouts/default.html.ep
<!DOCTYPE html>
<html>
  <head><title><%= title %></title></head>
  <body><%= content %></body>
</html>
```

## Fix

With regards to the comment from the code, adding the function to the `IO::Async::Loop` will automatically call `start` (via `::Loop::add` -> `::Loop::_add_noparentcheck` -> `::Notifier::__set_loop` -> `::Function::_add_to_loop` -> `::Function::start`). The only way to support a delayed thread start would be to delay adding this function to the loop. 

With the `::Loop->add()` method already calling `$function->start`, a direct call is not necessary  -- and when removed, the issues described above are resolved.

## What's Actually Going On?

This duplicate call not only spawns another worker (not quite expected behavior with the default `min_workers => 1`), but it also stops the loop from going out of scope (`DESTROY` never called). I am yet unable to explain why this happens, maybe @leonerd can drop by to provide some insight.