### PR TITLE
Die on errors during import

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,6 +9,10 @@ Revision history for OpenTelemetry-SDK
       initially because it depended on Google::ProtocolBuffers::Dynamic,
       but now it doesn't: it will use that distribution if it is
       available but use JSON otherwise.
+    * BREAKING CHANGE: the SDK will now die if it encounters an error
+      during initialisation. This will only affect the code executed
+      during import. Once the SDK has been loaded, it will never
+      intentionally raise an exception.
 
 0.024     2024-08-02 15:28:11+01:00 Europe/London
 

--- a/lib/OpenTelemetry/SDK.pm
+++ b/lib/OpenTelemetry/SDK.pm
@@ -5,18 +5,19 @@ our $VERSION = '0.025';
 
 use strict;
 use warnings;
-use experimental qw( signatures lexical_subs );
+use experimental qw( isa signatures lexical_subs );
 use feature 'state';
 
-use Module::Runtime;
 use Feature::Compat::Try;
+use Log::Any;
+use Module::Runtime;
 use OpenTelemetry::Common 'config';
 use OpenTelemetry::Propagator::Composite;
 use OpenTelemetry::SDK::Trace::TracerProvider;
-use OpenTelemetry;
+use OpenTelemetry::X;
 
 my sub configure_propagators {
-    my $logger = OpenTelemetry->logger;
+    my $logger = Log::Any->get_logger( category => 'OpenTelemetry' );
 
     state %map = (
         b3           => 'B3',
@@ -49,7 +50,9 @@ my sub configure_propagators {
             push @propagators, $class->new;
         }
         catch ($e) {
-            $logger->warnf("Error configuring '%s' propagator: %s", $name, $e);
+            die OpenTelemetry::X->create(
+                Invalid => "Error configuring '$name' propagator: $e",
+            );
         }
     }
 
@@ -58,7 +61,7 @@ my sub configure_propagators {
 }
 
 my sub configure_span_processors {
-    my $logger = OpenTelemetry->logger;
+    my $logger = Log::Any->get_logger( category => 'OpenTelemetry' );
 
     state %map = (
         jaeger  => '::Jaeger',
@@ -99,7 +102,9 @@ my sub configure_span_processors {
             );
         }
         catch ($e) {
-            $logger->warnf("Error configuring '%s' span processor: %s", $name, $e);
+            die OpenTelemetry::X->create(
+                Invalid => "Error configuring '$name' span processor: $e",
+            );
         }
     }
 
@@ -117,9 +122,9 @@ sub import ( $class ) {
         configure_span_processors();
     }
     catch ($e) {
-        OpenTelemetry->handle_error(
-            exception => $e,
-            message   => 'Unexpected configuration error'
+        die $e if $e isa OpenTelemetry::X;
+        die OpenTelemetry::X->create(
+            Invalid => "Unexpected error initialising OpenTelemetry::SDK: $e",
         );
     }
 }

--- a/lib/OpenTelemetry/SDK.pod
+++ b/lib/OpenTelemetry/SDK.pod
@@ -53,8 +53,17 @@ the environment.
 =head1 CONFIGURATION
 
 When loaded, the SDK will read its configuration from the environment and
-automatically apply those settings. This section lists the environment
-variables that are supported by the SDK and the way they are interpreted.
+automatically apply those settings. Starting with version 0.025, if an error
+is encountered during import, the SDK will raise an
+L<OpenTelemetry::X::Invalid> exception and terminate. While the
+L<specification|https://opentelemetry.io/docs/specs/otel/error-handling/#basic-error-handling-principles>
+is clear that "OpenTelemetry implementations MUST NOT
+throw unhandled exceptions at runtime" it explicitly states that the SDK
+"MAY I<fail fast> and cause the application to fail on initialization". This
+is the only scenario in which the SDK will potentially terminate a program.
+
+The remainder of this section lists the environment variables that are
+supported by the SDK and the way they are interpreted.
 
 The OpenTelemetry specification has
 L<a full list of variables|https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md>,


### PR DESCRIPTION
The [specification] states that

> OpenTelemetry implementations MUST NOT throw unhandled exceptions
> at run time.

but it also says that

> The [...] SDK MAY _fail fast_ and cause the application to fail on
> initialization, e.g. because of a bad user config or environment,
> but MUST NOT cause the application to fail later at run time, e.g.
> due to dynamic config settings received from the Collector.

Before this change, the SDK was not "failing fast" for the sake of application stability. However, this could result in setups that were misconfigured but kept running, giving the user the incorrect impression that things had gone according to plan. This made debugging harder.

The situation was made worse because before 56d6689b66cec4f8d1950750ed044f872e561ce1 (which added the OTLP exporter as a dependency of the SDK) because in that case the SDK was defaulting to a broken configuration state, and failing silently. This is no longer the case, so any remaining cases of a misconfigured SDK are bugs that should be addressed, and are probably going unnoticed by users.

Fixes #18, but at what cost?

[specification]: https://opentelemetry.io/docs/specs/otel/error-handling/#basic-error-handling-principles