### PR TITLE
Add initial programmatic configuration support

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for OpenTelemetry-SDK
 
 {{$NEXT}}
 
+    * Add initial support for programmatic configuration
+
 0.027     2025-05-08 08:50:57 BST
 
     * Switch to the internal logger added to OpenTelemetry v0.030.

--- a/lib/OpenTelemetry/SDK.pm
+++ b/lib/OpenTelemetry/SDK.pm
@@ -5,7 +5,7 @@ our $VERSION = '0.028';
 
 use strict;
 use warnings;
-use experimental qw( signatures lexical_subs );
+use experimental 'signatures';
 use feature 'state';
 
 use Feature::Compat::Try;
@@ -14,10 +14,13 @@ use OpenTelemetry::Common 'config';
 use OpenTelemetry::Propagator::Composite;
 use OpenTelemetry::SDK::Trace::TracerProvider;
 use OpenTelemetry::X;
+use OpenTelemetry;
+use Ref::Util 'is_coderef';
+use Scalar::Util 'blessed';
 
 use isa 'OpenTelemetry::X';
 
-my sub configure_propagators {
+sub configure_propagators ($, @args) {
     my $logger = OpenTelemetry::Common::internal_logger;
 
     state %map = (
@@ -31,16 +34,27 @@ my sub configure_propagators {
         xray         => 'XRay',
     );
 
-    my @names = split ',',
-        ( config('PROPAGATORS') // 'tracecontext,baggage' ) =~ s/\s//gr;
+    push @args, split ',',
+        ( config('PROPAGATORS') // 'tracecontext,baggage' ) =~ s/\s//gr
+        unless @args;
 
     my ( %seen, @propagators );
+    for my $candidate ( grep !!$_, @args ) {
+        if ( blessed $candidate ) {
+            if ( $candidate->DOES('OpenTelemetry::Propagator') ) {
+                push @propagators, $candidate;
+            }
+            else {
+                $logger->warnf("Attempted to configure a '%s' propagator, but it does not do the OpenTelemetry::Propagator role", ref $candidate );
+            }
+            next;
+        }
 
-    for my $name ( @names ) {
-        my $suffix = $map{$name} // do {
-            $logger->warnf("Unknown propagator '%s' cannot be configured", $name);
-            $map{none};
-        };
+        my $suffix = $map{$candidate};
+        unless ($suffix) {
+            $logger->warn("Unknown propagator '$candidate' cannot be configured");
+            next;
+        }
 
         next if $seen{$suffix}++;
 
@@ -52,21 +66,28 @@ my sub configure_propagators {
         }
         catch ($e) {
             die OpenTelemetry::X->create(
-                Invalid => "Error configuring '$name' propagator: $e",
+                Invalid => "Error configuring '$candidate' propagator: $e",
             );
         }
     }
 
+    # If we have no good ones, keep the default
+    return OpenTelemetry->propagator unless @propagators;
+
+    # If we have only one good one, set that one as the global one
+    return OpenTelemetry->propagator = shift @propagators if @propagators == 1;
+
+    # If we have multiple good ones, wrap them in a composite
     OpenTelemetry->propagator
         = OpenTelemetry::Propagator::Composite->new(@propagators),
 }
 
-my sub configure_span_processors {
+sub configure_tracer_provider ($, $provider = undef, @) {
     my $logger = OpenTelemetry::Common::internal_logger;
 
     state %map = (
         jaeger  => '::Jaeger',
-        otlp    => '::OTLP',
+        otlp    => '::OTLP::Traces',
         zipkin  => '::Zipkin',
         console => 'OpenTelemetry::SDK::Exporter::Console',
     );
@@ -74,7 +95,23 @@ my sub configure_span_processors {
     my @names = split ',',
         ( config('TRACES_EXPORTER') // 'otlp' ) =~ s/\s//gr;
 
-    my $tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider->new;
+    if ($provider) {
+        if ( ! blessed $provider ) {
+            $logger->warnf('Attempted to configure a tracer provider that was not a blessed reference: %s', $provider );
+            undef $provider;
+        }
+        elsif (
+            !$provider->can('tracer')
+         || !$provider->can('add_span_processor')
+         || !$provider->can('shutdown')
+         || !$provider->can('force_flush')
+        ) {
+            $logger->warnf("Attempted to configure a '%s' tracer provider, but it does not implement the OpenTelemetry::SDK::Trace::TracerProvider interface", ref $provider );
+            undef $provider;
+        }
+    }
+
+    $provider //= OpenTelemetry::SDK::Trace::TracerProvider->new;
 
     my %seen;
     for my $name ( @names ) {
@@ -98,7 +135,7 @@ my sub configure_span_processors {
             Module::Runtime::require_module $exporter;
             Module::Runtime::require_module $processor;
 
-            $tracer_provider->add_span_processor(
+            $provider->add_span_processor(
                 $processor->new( exporter => $exporter->new )
             );
         }
@@ -109,7 +146,7 @@ my sub configure_span_processors {
         }
     }
 
-    OpenTelemetry->tracer_provider = $tracer_provider;
+    OpenTelemetry->tracer_provider = $provider;
 }
 
 sub import ( $class ) {
@@ -119,8 +156,8 @@ sub import ( $class ) {
         # TODO: logger
         # TODO: error_handler
 
-        configure_propagators();
-        configure_span_processors();
+        configure_propagators(1);
+        configure_tracer_provider(1);
     }
     catch ($e) {
         die $e if isa_OpenTelemetry_X $e;

--- a/lib/OpenTelemetry/SDK.pod
+++ b/lib/OpenTelemetry/SDK.pod
@@ -17,6 +17,12 @@ OpenTelemetry::SDK - An implementation of the OpenTelemetry SDK for Perl
     use OpenTelemetry::Integration qw( HTTP::Tiny );
 
     # You can also configure some parts of the SDK manually
+    # like passing in your own tracer provider...
+    OpenTelemetry::SDK->configure_tracer_provider(
+        Local::TracerProvider->new( ... ),
+    );
+
+    # ... or adding custom processors to the existing one
     OpenTelemetry->tracer_provider->add_span_processor(
         OpenTelemetry::SDK::Trace::Span::Processor::Simple->new(
             exporter => OpenTelemetry::SDK::Exporter::Console->new,
@@ -61,6 +67,61 @@ is clear that "OpenTelemetry implementations MUST NOT
 throw unhandled exceptions at runtime" it explicitly states that the SDK
 "MAY I<fail fast> and cause the application to fail on initialization". This
 is the only scenario in which the SDK will potentially terminate a program.
+
+=head2 Programmatic Configuration
+
+L<OpenTelemetry::SDK> offers some means to configure it programmatically.
+The methods described in this section are the same that would normally get
+called when importing the SDK.
+
+=head3 configure_propagators
+
+    $propagator = OpenTelemetry::SDK->configure_propagators(
+        @propagators,
+    );
+
+This method takes a list of propagators, or propagator slugs, and configures
+them as the global propagators. If no arguments are passed in, then a
+default set of slugs will be read from the L</OTEL_PROPAGATORS> environment
+variable.
+
+Arguments to this method can be any of the names that could be set in that
+environment, or instances of propagators that I<do> the
+L<OpenTelemetry::Propagator> role. Any names that are not recognised, or
+objects that do not consume that role will be ignored.
+
+If after all the validation multiple valid propagators are present, they
+will be wrapped in a L<OpenTelemetry::Propagator::Composite>.
+
+This method returns the globally installed propagator.
+
+=head3 configure_tracer_provider
+
+    $provider = OpenTelemetry::SDK->configure_tracer_provider(
+        $provider // undef, # Optional
+    );
+
+This method optionally takes an instance of a tracer provider and configures
+it with the appropriate span processors and exporters. The provider passed as
+an argument must implement the tracer provider API. If it does not, it will
+be ignored and a warning will be logged.
+
+This method is useful if you want to apply the default configuration to a
+custom tracer provider. If you want to customise this even further, you can
+skip this method entirely and create your own pipelines:
+
+    my $exporter  = My::Exporter->new( ... );
+    my $processor = My::Processor->new( exporter => $exporter, ... );
+    my $provider  = My::Provider->new( ... );
+    $provider->add_span_processor($processor);
+    OpenTelemetry->trace_provider = $provider;
+
+If no argument is set, the provider will default to an internally constructed
+L<OpenTelemetry::SDK::Trace::TracerProvider>.
+
+This method returns the globally installed provider.
+
+=head2 Environment Variables
 
 The remainder of this section lists the environment variables that are
 supported by the SDK and the way they are interpreted.


### PR DESCRIPTION
There's been some [changes in the OpenTelemetry spec in the area around configuration](https://opentelemetry.io/docs/specs/otel/configuration/), in particular moving away from environment variables and towards what the spec calls "declarative" configuration. This is in effect configuration based on a config file.

The spec distinguishes between a "programmatic" configuration (which is language dependant and should allow access to "all configuration"), the environment-based configuration which we currently support, and the "declarative" configuration which is based on a language-agnostic configuration file. The spec states that "[all] configuration mechanisms SHOULD be built on top of [the programmatic] interface".

The SDK currently offers significant amount of control, but we know of some aspects where this is limited (see eg. #10) and it is entirely dependant on the environment.

This change aims to help with this, by exposing the methods the SDK was currently using internally to make it easier for users to customise the default setup.

With this change, the request in #9 could be implemented in the entrypoint as

```perl
use OpenTelemetry::SDK;
use OpenTelemetry::SDK::Resource;
use OpenTelemetry::SDK::Trace::TracerProvider;

my $resource = OpenTelemetry::SDK::Resource->new( attributes => { foo => 12311 } );
my $provider = OpenTelemetry::SDK::Trace::TracerProvider->new( resource => $resource );
OpenTelemetry::SDK->configure_tracer_provider($provider);
```

Support for the declarative configuration is still a work in progress, but I feel this unblocks a considerable part of that.

Comments on this are welcome.